### PR TITLE
[FP] Avoid linting for `$$` with `&convert`

### DIFF
--- a/rule-tests/use-dd-test.yml
+++ b/rule-tests/use-dd-test.yml
@@ -3,6 +3,7 @@ valid:
   - "type X = unit { x: uint8 { $$; } };"
   - "type X = unit { x: uint8 { other.y; } };"
   - "type X = unit { y: uint8 { self.x; } };"
+  - "type X = unit { x: uint8 &convert=$$ + 5 { self.x; $$; } };"
 invalid:
   - "type X = unit { x: uint8 { self.x; } };"
   - "type X = unit { x: uint8 { if (True) self.x; } };"

--- a/rules/use-dd.yml
+++ b/rules/use-dd.yml
@@ -25,6 +25,13 @@ rule:
               field: "name"
               kind: "ident"
               pattern: "$F"
+        not:
+          inside:
+            kind: "field_decl"
+            stopBy: "end"
+            has:
+              kind: "attribute"
+              regex: "&convert"
 
 fix: "$$"
 


### PR DESCRIPTION
Attributes on a field with `&convert` make `$$` mean something different. `$$` refers to before the conversion, `self.field` refers to after.

Obligatory note: There's more nuance, but I almost see it as a spicy bug. If you run the example and print both `self.x` and `$$`, you'll see they'll be the same. But if you try swapping them out in a `&requires`, they'll be different. That seems wrong to me, so I didn't add that logic in. Maybe worth an issue

BTW this is where it was triggering in spicy Redis, where the replacement makes Spicy not compile the code because that's before a type conversion:

https://github.com/evantypanski/spicy-redis/blob/8101fd33f1c3b3e627e6032741c3c42126790670/analyzer/resp.spicy#L108